### PR TITLE
Add script for training a branch predictor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ OBJECTS = $(patsubst $(SRC_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SOURCES))
 EXAMPLE_SRC = example.cpp
 EXAMPLE_BIN = $(BIN_DIR)/example
 
+# Branch predictor trainer executable
+TRAIN_BP_SRC = train_branch_predictor.cpp
+TRAIN_BP_BIN = $(BIN_DIR)/train_bp
+
 # Default target
 .PHONY: all
 all: directories static
@@ -58,6 +62,12 @@ run-example: example
 	@echo "Running example..."
 	@$(EXAMPLE_BIN)
 
+# Build branch predictor trainer executable
+.PHONY: train_bp
+train_bp: directories static
+	$(CXX) $(CXXFLAGS) -I$(INCLUDE_DIR) $(TRAIN_BP_SRC) -L$(LIB_DIR) -l$(LIB_NAME) -o $(TRAIN_BP_BIN)
+	@echo "Trainer executable created: $(TRAIN_BP_BIN)"
+
 # Debug build
 .PHONY: debug
 debug: CXXFLAGS += $(DEBUG_FLAGS)
@@ -77,6 +87,7 @@ help:
 	@echo "  static      - Build static library"
 	@echo "  example     - Build example executable"
 	@echo "  run-example - Build and run the example"
+	@echo "  train_bp    - Build branch predictor trainer"
 	@echo "  debug       - Build with debug symbols"
 	@echo "  clean       - Remove build artifacts"
 	@echo "  help        - Show this help message"

--- a/train_branch_predictor.cpp
+++ b/train_branch_predictor.cpp
@@ -1,0 +1,208 @@
+#include "mlp.h"
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Parse a CSV line to extract target and input bits
+ *
+ * @param line CSV line in format: <target>,<64-bit number>
+ * @param input_size Number of lowest bits to use as input
+ * @return std::pair<float, std::vector<float>> Target and input vector
+ */
+std::pair<float, std::vector<float>> parse_csv_line(const std::string &line,
+                                                    unsigned int input_size) {
+  std::stringstream ss(line);
+  std::string target_str, input_str;
+
+  // Parse: target,input
+  if (!std::getline(ss, target_str, ',') || !std::getline(ss, input_str)) {
+    throw std::runtime_error("Invalid CSV format: " + line);
+  }
+
+  // Parse target (0 or 1)
+  float target = std::stof(target_str);
+  if (target != 0.0f && target != 1.0f) {
+    throw std::runtime_error("Target must be 0 or 1, got: " + target_str);
+  }
+
+  // Parse input as 64-bit unsigned integer
+  unsigned long long input_num = std::stoull(input_str);
+
+  // Extract the lowest input_size bits as a vector of floats (0.0 or 1.0)
+  std::vector<float> inputs(input_size);
+  for (unsigned int i = 0; i < input_size; ++i) {
+    inputs[i] = static_cast<float>((input_num >> i) & 1);
+  }
+
+  return {target, inputs};
+}
+
+/**
+ * @brief Train MLP on CSV data in streaming/chunked fashion
+ *
+ * Reads CSV file in batches to avoid loading entire dataset into memory.
+ *
+ * @param network MLP network to train
+ * @param filename Path to CSV file
+ * @param input_size Number of lowest bits to use as input
+ * @param epochs Number of passes through the dataset
+ * @param learning_rate Learning rate for gradient descent
+ * @param batch_size Number of samples per training batch
+ * @return size_t Total number of samples processed
+ */
+size_t train_streaming(mlp::MLP &network, const std::string &filename,
+                       unsigned int input_size, unsigned int epochs,
+                       float learning_rate, size_t batch_size) {
+  size_t total_samples = 0;
+
+  for (unsigned int epoch = 0; epoch < epochs; ++epoch) {
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+      throw std::runtime_error("Failed to open file: " + filename);
+    }
+
+    std::vector<std::vector<float>> batch_inputs;
+    std::vector<float> batch_targets;
+    std::string line;
+    size_t line_number = 0;
+    size_t epoch_samples = 0;
+
+    batch_inputs.reserve(batch_size);
+    batch_targets.reserve(batch_size);
+
+    while (std::getline(file, line)) {
+      ++line_number;
+
+      // Skip empty lines
+      if (line.empty() ||
+          line.find_first_not_of(" \t\r\n") == std::string::npos) {
+        continue;
+      }
+
+      try {
+        auto [target, inputs] = parse_csv_line(line, input_size);
+        batch_targets.push_back(target);
+        batch_inputs.push_back(inputs);
+        ++epoch_samples;
+
+        // Train when batch is full
+        if (batch_inputs.size() >= batch_size) {
+          network.train(batch_inputs, batch_targets, 1, learning_rate);
+          batch_inputs.clear();
+          batch_targets.clear();
+        }
+
+      } catch (const std::exception &e) {
+        std::cerr << "Error on line " << line_number << ": " << e.what()
+                  << std::endl;
+        throw;
+      }
+    }
+
+    // Train on any remaining samples in the last incomplete batch
+    if (!batch_inputs.empty()) {
+      network.train(batch_inputs, batch_targets, 1, learning_rate);
+    }
+
+    file.close();
+
+    // Report progress
+    if (epoch == 0) {
+      total_samples = epoch_samples;
+      std::cout << "Epoch 1/" << epochs << " - " << epoch_samples
+                << " samples processed" << std::endl;
+    } else if ((epoch + 1) % std::max(1u, epochs / 10) == 0 ||
+               epoch == epochs - 1) {
+      std::cout << "Epoch " << (epoch + 1) << "/" << epochs << std::endl;
+    }
+  }
+
+  return total_samples;
+}
+
+void print_usage(const char *program_name) {
+  std::cout << "Usage: " << program_name
+            << " <csv_file> <input_size> <hidden_layer_size> [epochs] "
+               "[learning_rate] [batch_size]\n";
+  std::cout << "\n";
+  std::cout << "Arguments:\n";
+  std::cout << "  csv_file          - Path to CSV training data file\n";
+  std::cout << "                      Format: <target>,<64-bit number>\n";
+  std::cout << "  input_size        - Number of lowest bits to use as input "
+               "(1-64)\n";
+  std::cout << "  hidden_layer_size - Number of hidden layer neurons\n";
+  std::cout << "  epochs            - Number of training epochs (default: "
+               "1000)\n";
+  std::cout << "  learning_rate     - Learning rate (default: 0.1)\n";
+  std::cout << "  batch_size        - Samples per batch (default: 32)\n";
+  std::cout << "\n";
+  std::cout << "Example:\n";
+  std::cout << "  " << program_name << " training_data.csv 16 8 5000 0.5 64\n";
+  std::cout << "\n";
+  std::cout << "Note: Uses streaming/chunked training for large datasets.\n";
+}
+
+int main(int argc, char *argv[]) {
+  // Parse command line arguments
+  if (argc < 4 || argc > 7) {
+    print_usage(argv[0]);
+    return 1;
+  }
+
+  std::string csv_file = argv[1];
+  unsigned int input_size = std::stoul(argv[2]);
+  unsigned int hidden_layer_size = std::stoul(argv[3]);
+  unsigned int epochs = (argc >= 5) ? std::stoul(argv[4]) : 1000;
+  float learning_rate = (argc >= 6) ? std::stof(argv[5]) : 0.1f;
+  size_t batch_size = (argc >= 7) ? std::stoul(argv[6]) : 32;
+
+  // Validate input_size
+  if (input_size == 0 || input_size > 64) {
+    std::cerr << "Error: input_size must be between 1 and 64\n";
+    return 1;
+  }
+
+  // Validate batch_size
+  if (batch_size == 0) {
+    std::cerr << "Error: batch_size must be at least 1\n";
+    return 1;
+  }
+
+  try {
+    // Create MLP
+    std::cout << "Creating MLP with:\n";
+    std::cout << "  Input size: " << input_size << std::endl;
+    std::cout << "  Hidden layer size: " << hidden_layer_size << std::endl;
+    std::cout << "  Batch size: " << batch_size << std::endl;
+    mlp::MLP network(input_size, hidden_layer_size);
+
+    // Train the network with streaming
+    std::cout << "\nTraining from: " << csv_file << std::endl;
+    std::cout << "Epochs: " << epochs << ", Learning rate: " << learning_rate
+              << std::endl;
+    std::cout << "\nStarting training...\n";
+
+    size_t total_samples = train_streaming(network, csv_file, input_size,
+                                           epochs, learning_rate, batch_size);
+
+    std::cout << "\nTraining complete!" << std::endl;
+    std::cout << "Total samples per epoch: " << total_samples << std::endl;
+
+    // Save weights
+    std::cout << "\nSaving weights..." << std::endl;
+    network.save_weights();
+    std::string weights_file = "mlp_" + std::to_string(input_size) + "_" +
+                               std::to_string(hidden_layer_size) + ".txt";
+    std::cout << "Weights saved to: " << weights_file << std::endl;
+
+    return 0;
+
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
This script will process a training data file in chunks specified by the `batch_size` argument. The following shows output from running this on a 517MB csv training file, with an input size of 30, hidden layer size of 2, 500 epochs, learning rate of 0.2, and batch size of 4096.

@tnl3pdx let me know if you want to take a look at this one before I merge.

```sh
boolean-predictor-MLP git:(main) ✗ time ./bin/train_bp mlp_training_data_20251125_102015.csv 30 2 500 0.2 4096
Creating MLP with:
  Input size: 30
  Hidden layer size: 2
  Batch size: 4096

Training from: mlp_training_data_20251125_102015.csv
Epochs: 500, Learning rate: 0.2

Starting training...
Epoch 1/500 - 23397542 samples processed
Epoch 50/500
Epoch 100/500
Epoch 150/500
Epoch 200/500
Epoch 250/500
Epoch 300/500
Epoch 350/500
Epoch 400/500
Epoch 450/500
Epoch 500/500

Training complete!
Total samples per epoch: 23397542

Saving weights...
Weights saved to: mlp_30_2.txt
./bin/train_bp mlp_training_data_20251125_102015.csv 30 2 500 0.2 4096  7778.50s user 92.26s system 94% cpu 2:18:39.32 total
```